### PR TITLE
feat(core): Add pages linked to in footer

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,10 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path("..", "..", "src").resolve()))
+
 project = "HCI"
 copyright = "Clinical Genome Resource"
 author = "The Stanford ClinGen Team"
 release = "0.1"
 version = "0.1.0"
 
-extensions = []
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
 
 templates_path = ["_templates"]
 exclude_patterns = []

--- a/docs/source/reference-guides.rst
+++ b/docs/source/reference-guides.rst
@@ -2,6 +2,19 @@
 Reference Guides
 ================
 
+------------
+The Core App
+------------
+
+The core app is where the home page and the pages found in the HCI's footer are housed.
+It is also used to house modules that aren't app-specific.
+
+``core.views``
+==============
+
+.. automodule:: core.views
+   :members:
+
 ----------------
 Code Conventions
 ----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ convention = "google"
 ]
 "tests.py" = [
     "ANN201", # Tests should always return `None`.
+    "D101", # Tests should be obvious enough not to require docstrings.
     "D102", # Tests should be obvious enough not to require docstrings.
 ]
 

--- a/src/core/templates/core/about.html
+++ b/src/core/templates/core/about.html
@@ -1,0 +1,12 @@
+{% extends "core/layouts/page.html" %}
+{% block title %}About{% endblock %}
+{% block description %}About the HLA Curation Interface.{% endblock %}
+{% block heading %}About{% endblock %}
+{% block content %}
+    <p>
+        The HLA Curation Interface (HCI) is a tool designed to facilitate the
+        curation of information about HLA alleles and haplotypes. It is developed
+        and maintained by the Stanford University contingent of the Clinical Genome
+        Resource project.
+    </p>
+{% endblock %}

--- a/src/core/templates/core/acknowledgements.html
+++ b/src/core/templates/core/acknowledgements.html
@@ -1,0 +1,19 @@
+{% extends "core/layouts/page.html" %}
+{% block title %}Acknowledgements{% endblock %}
+{% block description %}Acknowledgements for the HLA Curation Interface.{% endblock %}
+{% block heading %}Acknowledgements{% endblock %}
+{% block content %}
+    <div class="block">
+        <p>
+            We would like to thank the NIH/NHGRI for their financial support, which has
+            made the HCI possible.
+        </p>
+    </div>
+    <div class="block">
+        <p>
+            We are grateful to the contributors who provided assistance in developing
+            the HCI. In particular, we would like to thank
+            <a href="https://profiles.ucsf.edu/steven.mack">Steven Mack</a>.
+        </p>
+    </div>
+{% endblock %}

--- a/src/core/templates/core/citing.html
+++ b/src/core/templates/core/citing.html
@@ -1,0 +1,20 @@
+{% extends "core/layouts/page.html" %}
+{% block title %}Citing{% endblock %}
+{% block description %}Guidelines for citing the HLA Curation Interface.{% endblock %}
+{% block heading %}Citing{% endblock %}
+{% block content %}
+    <div class="block">
+        <p>
+            When citing the HCI in your work, please use the following format.
+        </p>
+    </div>
+    <div class="block">
+        <pre>Clinical Genome Resource. HLA Curation Interface. Stanford University. Retrieved from https://hci.clinicalgenome.org.</pre>
+    </div>
+    <div class="block">
+        <p>
+            If you used data from the HCI in your research, please also cite the
+            specific dataset and the date it was downloaded.
+        </p>
+    </div>
+{% endblock %}

--- a/src/core/templates/core/collaborators.html
+++ b/src/core/templates/core/collaborators.html
@@ -1,0 +1,20 @@
+{% extends "core/layouts/page.html" %}
+{% block title %}Collaborators{% endblock %}
+{% block description %}Collaborators of the HLA Curation Interface.{% endblock %}
+{% block heading %}Collaborators{% endblock %}
+{% block content %}
+    <div class="content">
+        <ul>
+            <li>
+                <a href="https://clinicalgenome.org/about/organizations/baylor-college-of-medicine/">
+                    The Baylor College of Medicine ClinGen Team
+                </a>
+            </li>
+            <li>
+                <a href="https://www.pharmgkb.org/">
+                    PharmGKB
+                </a>
+            </li>
+        </ul>
+    </div>
+{% endblock %}

--- a/src/core/templates/core/contact.html
+++ b/src/core/templates/core/contact.html
@@ -1,0 +1,14 @@
+{% extends "core/layouts/page.html" %}
+{% block title %}Contact{% endblock %}
+{% block description %}Contact the maintainers of the HLA Curation
+    Interface.{% endblock %}
+{% block heading %}Contact{% endblock %}
+{% block content %}
+    <div class="block">
+        <p>
+            If you need to contact the maintainers of the HCI, email
+            <a href="mailto:helpdesk@clinicalgenome.org">helpdesk@clinicalgenome.org</a>
+            with "HCI" in the subject.
+        </p>
+    </div>
+{% endblock %}

--- a/src/core/templates/core/downloads.html
+++ b/src/core/templates/core/downloads.html
@@ -1,0 +1,47 @@
+{% extends "core/layouts/page.html" %}
+{% block title %}Downloads{% endblock %}
+{% block description %}Download curation from the HLA Curation Interface.{% endblock %}
+{% block heading %}Downloads{% endblock %}
+{% block content %}
+    <div class="block">
+        <p>
+            HCI data are subject to the
+            <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons
+                CC BY-SA 4.0</a>
+            license.
+        </p>
+    </div>
+    <div class="block table-container">
+        <table class="table is-hoverable">
+            <thead>
+            <tr>
+                <th>Description</th>
+                <th>Download</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>Allele and Haplotype Curations</td>
+                <td>
+                    <a href="#" class="button is-small">CSV</a>
+                    <a href="#" class="button is-small">JSON</a>
+                </td>
+            </tr>
+            <tr>
+                <td>Allele Curations</td>
+                <td>
+                    <a href="#" class="button is-small">CSV</a>
+                    <a href="#" class="button is-small">JSON</a>
+                </td>
+            </tr>
+            <tr>
+                <td>Haplotype Curations</td>
+                <td>
+                    <a href="#" class="button is-small">CSV</a>
+                    <a href="#" class="button is-small">JSON</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+{% endblock %}

--- a/src/core/templates/core/help.html
+++ b/src/core/templates/core/help.html
@@ -1,0 +1,28 @@
+{% extends "core/layouts/page.html" %}
+{% block title %}Help{% endblock %}
+{% block description %}Get help for the HLA Curation Interface.{% endblock %}
+{% block heading %}Help{% endblock %}
+{% block content %}
+    <div class="block">
+        <p>
+            The user documentation for the HCI can be found <a href="#">here</a>.
+        </p>
+    </div>
+    <div class="block">
+        <p>
+            If you encounter an issue with the HCI, email
+            <a href="mailto:helpdesk@clinicalgenome.org">helpdesk@clinicalgenome.org</a>
+            with "HCI" in the subject. Please include the following information in your
+            email.
+        </p>
+    </div>
+    <div class="content">
+        <ul>
+            <li>A concise description of the issue.</li>
+            <li>Steps to reproduce the issue.</li>
+            <li>Your operating system, e.g., Windows, macOS, Linux.</li>
+            <li>Your web browser, e.g., Chrome, Firefox, Safari.</li>
+            <li>Screenshots or copy-pasted error messages, if applicable.</li>
+        </ul>
+    </div>
+{% endblock %}

--- a/src/core/templates/core/home.html
+++ b/src/core/templates/core/home.html
@@ -1,6 +1,14 @@
 {% extends "layouts/base.html" %}
 {% block title %}Home{% endblock %}
-{% block description %}The home page of the HLA Curation Interface.{% endblock %}
+{% block description %}Curate information about HLA alleles and
+    haplotypes.{% endblock %}
 {% block main %}
-    <p>This is the home page for the HCI.</p>
+    <div class="block mt-6">
+        <section class="hero is-light">
+            <div class="hero-body">
+                <p class="title">HLA Curation Interface</p>
+                <p class="subtitle">You are not logged in.</p>
+            </div>
+        </section>
+    </div>
 {% endblock %}

--- a/src/core/templates/core/layouts/page.html
+++ b/src/core/templates/core/layouts/page.html
@@ -1,0 +1,9 @@
+{% extends "layouts/base.html" %}
+{% block main %}
+    <div class="block mt-6">
+        <h1 class="title">{% block heading %}{% endblock %}</h1>
+    </div>
+    <div class="block mb-6">
+        {% block content %}{% endblock %}
+    </div>
+{% endblock %}

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -5,13 +5,130 @@ from django.urls import reverse
 
 
 class HomeViewTest(TestCase):
-    """Tests the home view."""
-
     def setUp(self):
-        """Sets up the mock browser and the URL for the tests."""
         self.client = Client()
         self.url = reverse("home")
 
     def test_response_code(self):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
+
+    def test_content(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "HLA Curation Interface")
+
+
+class AboutViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("about")
+
+    def test_response_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_content(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "About")
+        self.assertContains(response, "HLA Curation Interface (HCI)")
+        self.assertContains(response, "alleles")
+        self.assertContains(response, "haplotypes")
+        self.assertContains(response, "Stanford University")
+
+
+class ContactViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("contact")
+
+    def test_response_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_content(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Contact")
+        self.assertContains(response, "email")
+        self.assertContains(response, "helpdesk@clinicalgenome.org")
+
+
+class HelpViewTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("help")
+
+    def test_response_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_content(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Help")
+        self.assertContains(response, "user documentation")
+        self.assertContains(response, "email")
+        self.assertContains(response, "helpdesk@clinicalgenome.org")
+
+
+class DownloadsViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("downloads")
+
+    def test_response_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_content(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Downloads")
+        self.assertContains(response, "CC BY-SA 4.0")
+        self.assertContains(response, "CSV")
+        self.assertContains(response, "JSON")
+
+
+class CitingViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("citing")
+
+    def test_response_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_content(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Citing")
+        self.assertContains(response, "format")
+        self.assertContains(response, "dataset")
+
+
+class AcknowledgementsViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("acknowledgements")
+
+    def test_response_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_content(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Acknowledgements")
+        self.assertContains(response, "NIH/NHGRI")
+        self.assertContains(response, "Steven Mack")
+
+
+class CollaboratorsViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("collaborators")
+
+    def test_response_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_content(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Collaborators")
+        self.assertContains(response, "The Baylor College of Medicine ClinGen Team")
+        self.assertContains(response, "PharmGKB")

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -4,4 +4,13 @@ from django.urls import path
 
 from core import views
 
-urlpatterns = [path("", views.home, name="home")]
+urlpatterns = [
+    path("", views.home, name="home"),
+    path("about", views.about, name="about"),
+    path("acknowledgements", views.acknowledgements, name="acknowledgements"),
+    path("citing", views.citing, name="citing"),
+    path("collaborators", views.collaborators, name="collaborators"),
+    path("contact", views.contact, name="contact"),
+    path("downloads", views.downloads, name="downloads"),
+    path("help", views.help_, name="help"),
+]

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -7,3 +7,38 @@ from django.shortcuts import render
 def home(request: HttpRequest) -> HttpResponse:
     """Returns the home page."""
     return render(request, "core/home.html")
+
+
+def about(request: HttpRequest) -> HttpResponse:
+    """Returns the about page."""
+    return render(request, "core/about.html")
+
+
+def contact(request: HttpRequest) -> HttpResponse:
+    """Returns the contact page."""
+    return render(request, "core/contact.html")
+
+
+def help_(request: HttpRequest) -> HttpResponse:
+    """Returns the help page."""
+    return render(request, "core/help.html")
+
+
+def downloads(request: HttpRequest) -> HttpResponse:
+    """Returns the downloads page."""
+    return render(request, "core/downloads.html")
+
+
+def citing(request: HttpRequest) -> HttpResponse:
+    """Returns the citing page."""
+    return render(request, "core/citing.html")
+
+
+def acknowledgements(request: HttpRequest) -> HttpResponse:
+    """Returns the acknowledgements page."""
+    return render(request, "core/acknowledgements.html")
+
+
+def collaborators(request: HttpRequest) -> HttpResponse:
+    """Returns the collaborators page."""
+    return render(request, "core/collaborators.html")

--- a/src/templates/partials/footer.html
+++ b/src/templates/partials/footer.html
@@ -20,21 +20,21 @@
         </div>
         <div class="column">
             <ul>
-                <li><a href="#">About</a></li>
-                <li><a href="#">Contact</a></li>
-                <li><a href="#">Help</a></li>
+                <li><a href="{{ url('about') }}">About</a></li>
+                <li><a href="{{ url('contact') }}">Contact</a></li>
+                <li><a href="{{ url('help') }}">Help</a></li>
             </ul>
         </div>
         <div class="column">
             <ul>
-                <li><a href="#">Downloads</a></li>
-                <li><a href="#">Citing</a></li>
+                <li><a href="{{ url('downloads') }}">Downloads</a></li>
+                <li><a href="{{ url('citing') }}">Citing</a></li>
             </ul>
         </div>
         <div class="column">
             <ul>
-                <li><a href="#">Acknowledgements</a></li>
-                <li><a href="#">Collaborators</a></li>
+                <li><a href="{{ url('acknowledgements') }}">Acknowledgements</a></li>
+                <li><a href="{{ url('collaborators') }}">Collaborators</a></li>
             </ul>
         </div>
     </div>

--- a/src/templates/partials/header.html
+++ b/src/templates/partials/header.html
@@ -1,1 +1,7 @@
-<h1 class="title">HLA Curation Interface</h1>
+<nav class="navbar" role="navigation" aria-label="main navigation">
+    <div class="navbar-menu">
+        <div class="navbar-start">
+            <a href="{{ url('home') }}" class="navbar-item">Home</a>
+        </div>
+    </div>
+</nav>


### PR DESCRIPTION
This PR introduces pages that are linked to in the footer.

### Issue

https://github.com/ClinGen/hla-curation-interfacae/issues/1

### Description

Adds several core pages that we linked to, but didn't provide pages for.

### Checklist

- [x] The **implementation** focuses on a single change.
- [x] The commit for this PR has **tests** that demonstrate the implementation works.
- [x] The **documentation** has been updated to reflect the changes in this PR.
- [x] The commit for this PR contains a link to the **issue thread** for this PR.
