### PR TITLE
feat(common): Add Git SHA to footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 coverage.xml
 firebase-account-key*
 inventory.ini
+version.txt
 
 .ansible/
 .mypy_cache/

--- a/infra/ansible/tasks/admin/git_sha.yml
+++ b/infra/ansible/tasks/admin/git_sha.yml
@@ -1,0 +1,4 @@
+- name: Generate shortened Git SHA
+  ansible.builtin.command:
+    chdir: "{{ repo_dir }}"
+    cmd: "git rev-parse --short HEAD > version.txt"

--- a/src/common/context_processors.py
+++ b/src/common/context_processors.py
@@ -3,6 +3,6 @@
 from django.conf import settings
 
 
-def git_sha(request) -> dict:  # noqa: ANN001 (Required to have the param.)
+def git_sha(request) -> dict:  # noqa (Required to have the param.)
     """Returns the shortened Git SHA."""
     return {"GIT_SHA": settings.GIT_SHA}

--- a/src/common/context_processors.py
+++ b/src/common/context_processors.py
@@ -1,0 +1,8 @@
+"""Houses context processors used throughout the app."""
+
+from django.conf import settings
+
+
+def git_sha(request) -> dict:  # noqa: ANN001 (Required to have the param.)
+    """Returns the shortened Git SHA."""
+    return {"GIT_SHA": settings.GIT_SHA}

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -15,6 +15,13 @@ sentry_sdk.init(
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
+try:
+    version_file_path = Path(BASE_DIR / "version.txt")
+    with version_file_path.open(encoding="utf-8") as f:
+        GIT_SHA = f.read().strip()
+except Exception:
+    GIT_SHA = "dev"
+
 SECRET_KEY = os.getenv("SECRET_KEY")
 
 INSTALLED_APPS = [
@@ -63,6 +70,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "common.context_processors.git_sha",
             ],
         },
     },

--- a/src/publication/tests.py
+++ b/src/publication/tests.py
@@ -305,7 +305,9 @@ class PublicationSearchTest(TestCase):
         response = self.client.get(self.url)
         soup = BeautifulSoup(response.content, "html.parser")
         year_label = (
-            soup.find("label", {"for": "sort-publication-year-button"}).get_text().strip()
+            soup.find("label", {"for": "sort-publication-year-button"})
+            .get_text()
+            .strip()
         )
         self.assertEqual(year_label, "Year")
         year_button = soup.find(id="sort-publication-year-button")
@@ -314,11 +316,11 @@ class PublicationSearchTest(TestCase):
     def test_shows_title_in_tbody(self):
         response = self.client.get(self.url)
         soup = BeautifulSoup(response.content, "html.parser")
-        title = soup.find("tbody").find("tr").find_all("td")[4].get_text().strip()
+        title = soup.find("tbody").find("tr").find_all("td")[3].get_text().strip()
         self.assertEqual(title, "Diseases in grass type Pokémon in the Kanto region")
 
     def test_shows_added_in_tbody(self):
         response = self.client.get(self.url)
         soup = BeautifulSoup(response.content, "html.parser")
-        added_at = soup.find("tbody").find("tr").find_all("td")[5].get_text().strip()
+        added_at = soup.find("tbody").find("tr").find_all("td")[7].get_text().strip()
         self.assertIn("1990-01-01", added_at)

--- a/src/templates/partials/footer.html
+++ b/src/templates/partials/footer.html
@@ -51,5 +51,8 @@
             The source code is subject to the
             <a href="https://opensource.org/license/MIT">MIT License</a>.
         </p>
+        <p>
+            {{ GIT_SHA }}
+        </p>
     </div>
 </div>


### PR DESCRIPTION
### Issue

https://github.com/ClinGen/hla-curation-interface/issues/52

### Description

Adds the shortened Git SHA to the footer of every page.

### Checklist

- [x] The **implementation** focuses on a single change.
- [ ] ~~The commit for this PR has **tests** that demonstrate the implementation works.~~
- [ ] ~~The **documentation** has been updated to reflect the changes in this PR.~~
- [x] The commit for this PR contains a link to the **issue thread** for this PR.
